### PR TITLE
Improve UX of operator view

### DIFF
--- a/src/Controller/Api.cpp
+++ b/src/Controller/Api.cpp
@@ -14,7 +14,7 @@
 Api::Api() {
 #ifdef USE_INTERSYNTH
 
-    loveCommunicationTcp_.connectToServer("10.121.101.205", 4893);
+    // loveCommunicationTcp_.connectToServer("10.121.101.205", 4893);
 
     loveCommunicationTcp_.removeCarrier(0); // All operators removed in the beginning
     loveCommunicationTcp_.removeCarrier(1); // All operators removed in the beginning

--- a/src/Controller/Controller.cpp
+++ b/src/Controller/Controller.cpp
@@ -9,15 +9,35 @@
 
 const int kMaxNumberOfOperators = 8;
 
-std::unique_ptr<Controller> Controller::instance = std::make_unique<Controller>();
+std::unique_ptr <Controller> Controller::instance = std::make_unique<Controller>();
 
-Controller::Controller(QObject *parent) : QObject(parent){
+Controller::Controller(QObject *parent) : QObject(parent) {
     resetAvailableOperatorIds();
+    loadInitialPreset();
 }
 
-bool Controller::isConnected(){
+bool Controller::isConnected() {
     //Breki - checks if connection to the synth is working
     return true;
+}
+
+void Controller::loadInitialPreset() {
+    Operators defaultOperators;
+    defaultOperators.insert(
+            std::make_pair<int, Operator>(1, Operator(1, 140, 60, false, true, {0}, QPointF(0.4696, 0.894))));
+    defaultOperators.insert(
+            std::make_pair<int, Operator>(0, Operator(0, 70, 30, true, false, {}, QPointF(0.3251, 0.6075))));
+
+    // TODO: Configure these values better
+    const std::vector<AmpEnvValue> defaultAmpEnv = {
+        AmpEnvValue(0, 0.5328, 0, true),
+                AmpEnvValue(1, 0, 1, false),
+                AmpEnvValue(2, 0.5328, 0.6404, true),
+                AmpEnvValue(3, 0.5328, 5.0, true)
+    };
+
+    const auto defaultPreset = Preset(defaultOperators, defaultAmpEnv);
+    changeToPreset(defaultPreset);
 }
 
 std::optional<int> Controller::addOperator() {
@@ -30,7 +50,7 @@ std::optional<int> Controller::addOperator() {
     availableOperatorIds_.erase(id);
 
     auto op = Operator(id);
-    operators_.insert(std::make_pair<int, Operator>((int)id, std::move(op)));
+    operators_.insert(std::make_pair<int, Operator>((int) id, std::move(op)));
 
     return id;
 }
@@ -43,9 +63,12 @@ void Controller::removeOperator(int operatorId) {
     availableOperatorIds_.insert(operatorId);
 
     // Remove operator from all modulatedBy lists
-    for (auto& op : operators_) {
-        if (std::find(op.second.modulatedBy.begin(), op.second.modulatedBy.end(), operatorId) != op.second.modulatedBy.end()) {
-            op.second.modulatedBy.erase(std::remove(op.second.modulatedBy.begin(), op.second.modulatedBy.end(), operatorId),op.second.modulatedBy.end());
+    for (auto &op: operators_) {
+        if (std::find(op.second.modulatedBy.begin(), op.second.modulatedBy.end(), operatorId) !=
+            op.second.modulatedBy.end()) {
+            op.second.modulatedBy.erase(
+                    std::remove(op.second.modulatedBy.begin(), op.second.modulatedBy.end(), operatorId),
+                    op.second.modulatedBy.end());
             api.removeModulator(op.second.id, operatorId);
         }
     }
@@ -62,12 +85,13 @@ void Controller::noteOff(int note) {
 void Controller::setAmpEnvelopeSize(int size) {
     api.setAmpEnvelopeSize(size);
 }
-void Controller::setAttackAmpEnvelopePoint(int index, float value, float time){
+
+void Controller::setAttackAmpEnvelopePoint(int index, float value, float time) {
     api.setAmpEnvelopeAttackValue(index, value, time);
     ampEnvValues_[index] = AmpEnvValue(index, value, time, true);
 }
 
-void Controller::setReleaseAmpEnvelopePoint(int index, float value, float time){
+void Controller::setReleaseAmpEnvelopePoint(int index, float value, float time) {
     api.setAmpReleaseEnvelopePoint(index, value, time);
     ampEnvValues_[index] = AmpEnvValue(index, value, time, false);
 }
@@ -85,8 +109,8 @@ void Controller::changeAmplitude(int operatorId, long amplitude) {
 }
 
 void Controller::addModulator(int operatorId, int modulatorId) {
-    auto& op = operators_[operatorId];
-    auto& mod = operators_[modulatorId];
+    auto &op = operators_[operatorId];
+    auto &mod = operators_[modulatorId];
 
     op.modulatedBy.push_back(modulatorId);
     mod.isModulator = true;
@@ -95,15 +119,16 @@ void Controller::addModulator(int operatorId, int modulatorId) {
 }
 
 void Controller::removeModulator(int operatorId, int modulatorId) {
-    auto& op = operators_[operatorId];
-    auto& mod = operators_[modulatorId];
+    auto &op = operators_[operatorId];
+    auto &mod = operators_[modulatorId];
 
     op.modulatedBy.erase(std::remove(op.modulatedBy.begin(), op.modulatedBy.end(), modulatorId), op.modulatedBy.end());
     api.removeModulator(operatorId, modulatorId);
 
     // Check if modulator is modulating any other operator before setting isModulator to false
-    for (const auto& op_ : operators_) {
-        if (std::find(op_.second.modulatedBy.begin(), op_.second.modulatedBy.end(), modulatorId) == op_.second.modulatedBy.end()) {
+    for (const auto &op_: operators_) {
+        if (std::find(op_.second.modulatedBy.begin(), op_.second.modulatedBy.end(), modulatorId) ==
+            op_.second.modulatedBy.end()) {
             return;
         }
     }
@@ -125,15 +150,15 @@ void Controller::removeCarrier(int operatorId) {
 }
 
 void Controller::sendOperator(int operatorId) {
-    const auto& op = operators_[operatorId];
+    const auto &op = operators_[operatorId];
     // Núverandi range 0 - 200 20 er lægsta nóta sem heyrist hæsta er 175 þá er 100 byrjunar nóta.
-    float freq = std::pow(1.90366, (float)(op.frequency - 100)/20.0);
+    float freq = std::pow(1.90366, (float) (op.frequency - 100) / 20.0);
     std::cout << "Ayy: " << freq << std::endl;
-    float amp = std::pow(1.6, (float)(op.amplitude - 50)/20.0) - 0.3;
+    float amp = std::pow(1.6, (float) (op.amplitude - 50) / 20.0) - 0.3;
     api.sendOperatorValue(op.id, 0, 1, freq, amp);
     //api.sendOperatorValue(op->id, 1, 0, std::pow(1.3, (((op->frequency/200.0*100.0)-50.0)/20.0)), std::pow(1.3, (((op->amplitude/60.0*100.0)-50)/20.0))-0.3);
     //api.sendOperatorValue(op->id, 1, 0, std::pow(1.90366, ((float)op->frequency / 20.0)), std::pow(1.6, (((float)(op->amplitude)-50)/20.0))-0.3);
-   // api.sendOperatorValue(op->id, 1, 0, std::pow(1.3, (((op->frequency/20000.0*100.0)-50.0)/20.0)), std::pow(1.3, (((op->amplitude/60.0*100.0)-50)/20.0)));
+    // api.sendOperatorValue(op->id, 1, 0, std::pow(1.3, (((op->frequency/20000.0*100.0)-50.0)/20.0)), std::pow(1.3, (((op->amplitude/60.0*100.0)-50)/20.0)));
 }
 
 void Controller::sendAllOperatorInfo(int operatorId, std::unordered_set<int> *visited) {
@@ -145,14 +170,14 @@ void Controller::sendAllOperatorInfo(int operatorId, std::unordered_set<int> *vi
     }
     visited_->insert(operatorId);
 
-    const auto& operator_ = getOperatorById(operatorId);
+    const auto &operator_ = getOperatorById(operatorId);
     if (operator_.isCarrier) {
         api.addCarrier(operatorId);
     }
 
     sendOperator(operatorId);
 
-    for (const auto& modulatorId : operator_.modulatedBy) {
+    for (const auto &modulatorId: operator_.modulatedBy) {
         api.addModulator(operatorId, modulatorId);
 
         sendAllOperatorInfo(modulatorId, visited_);
@@ -166,7 +191,7 @@ void Controller::sendAllOperatorInfo(int operatorId, std::unordered_set<int> *vi
 
 void Controller::selectOperator(int id) {
     selectedOperatorId_ = {id};
-    auto& operator_ = operators_[selectedOperatorId_.value()];
+    auto &operator_ = operators_[selectedOperatorId_.value()];
     emit operatorSelected(&operator_);
 }
 
@@ -191,18 +216,17 @@ std::optional<int> Controller::selectedOperatorId() {
     return selectedOperatorId_;
 }
 
-Operator* Controller::getSelectedOperator() {
+Operator *Controller::getSelectedOperator() {
     if (selectedOperatorId_.has_value()) {
-        auto& operator_ = operators_[selectedOperatorId_.value()];
+        auto &operator_ = operators_[selectedOperatorId_.value()];
         return &operator_;
-    }
-    else {
+    } else {
         return nullptr;
     }
 }
 
-void Controller::savePreset(const std::string& name) {
-    std::vector<AmpEnvValue> ampEnvPoints (std::begin(ampEnvValues_), std::end(ampEnvValues_));
+void Controller::savePreset(const std::string &name) {
+    std::vector <AmpEnvValue> ampEnvPoints(std::begin(ampEnvValues_), std::end(ampEnvValues_));
     json json(Preset(operators_, ampEnvPoints));
 
     std::ofstream file("presets/" + name + ".json");
@@ -210,22 +234,22 @@ void Controller::savePreset(const std::string& name) {
     file.close();
 }
 
-void Controller::loadPreset(const std::string& name) {
+void Controller::loadPreset(const std::string &name) {
     auto preset = loadJsonFileAsObject<Preset>("presets/" + name + ".json");
 
     resetAvailableOperatorIds();
-    for (const auto& operator_ : operators_) {
+    for (const auto &operator_: operators_) {
         availableOperatorIds_.erase(operator_.first);
     }
 }
 
-void Controller::changeToPreset(const Preset& preset) {
+void Controller::changeToPreset(const Preset &preset) {
     removeAllModulators();
     removeAllCarriers();
     operators_ = preset.operators;
 
     resetAvailableOperatorIds();
-    for (const auto& operator_ : operators_) {
+    for (const auto &operator_: operators_) {
         availableOperatorIds_.erase(operator_.first);
 
         if (operator_.second.isCarrier) {
@@ -233,21 +257,20 @@ void Controller::changeToPreset(const Preset& preset) {
         }
     }
 
-    for (const auto& ampEnvValue : preset.empEnvValues) {
+    for (const auto &ampEnvValue: preset.empEnvValues) {
         if (ampEnvValue.attack) {
             setAttackAmpEnvelopePoint(ampEnvValue.index, ampEnvValue.value, ampEnvValue.time);
-        }
-        else {
+        } else {
             setReleaseAmpEnvelopePoint(ampEnvValue.index, ampEnvValue.value, ampEnvValue.time);
         }
     }
 }
 
 void Controller::removeAllModulators() {
-    for (const auto& operator_ : operators_) {
+    for (const auto &operator_: operators_) {
         const auto modulatedBy = operator_.second.modulatedBy;
 
-        for (const auto& modulator : modulatedBy) {
+        for (const auto &modulator: modulatedBy) {
             removeModulator(operator_.first, modulator);
         }
     }
@@ -256,13 +279,13 @@ void Controller::removeAllModulators() {
 void Controller::removeAllModulatorsForOperator(int operatorId) {
     const auto modulatedBy = getOperatorById(operatorId).modulatedBy;
 
-    for (const auto& modulator : modulatedBy) {
+    for (const auto &modulator: modulatedBy) {
         removeModulator(operatorId, modulator);
     }
 }
 
 void Controller::removeAllCarriers() {
-    for (const auto& operator_ : operators_) {
+    for (const auto &operator_: operators_) {
         if (operator_.second.isCarrier) {
             removeCarrier(operator_.first);
         }

--- a/src/Controller/Controller.h
+++ b/src/Controller/Controller.h
@@ -72,6 +72,8 @@ private:
     AmpEnvValue ampEnvValues_[4] = {AmpEnvValue(0, true), AmpEnvValue(1, true), AmpEnvValue(2, true), AmpEnvValue(3, false)};
     Api api;
     bool showPresets_;
+
+    void loadInitialPreset();
 };
 
 #endif

--- a/src/Controller/Operator.cpp
+++ b/src/Controller/Operator.cpp
@@ -6,9 +6,25 @@
 #include "qcolor.h"
 #include <iostream>
 
+// Operator view state
 
-Operator::Operator(int id, QObject* parent)
-    : id(id), QObject(parent), frequency(100), amplitude(60), isCarrier(false), isModulator(false) {}
+OperatorViewState::OperatorViewState() : isBeingDragged(false) {
+
+}
+
+OperatorViewState::OperatorViewState(const OperatorViewState &operatorViewState) : isBeingDragged(
+        operatorViewState.isBeingDragged),
+                                                                                   draggingState(
+                                                                                           operatorViewState.draggingState),
+                                                                                   initialDragCursorPos(
+                                                                                           operatorViewState.initialDragCursorPos) {
+
+}
+
+// Operator
+
+Operator::Operator(int id, QObject *parent)
+        : id(id), QObject(parent), frequency(100), amplitude(60), isCarrier(false), isModulator(false) {}
 
 Operator::Operator()
         : id(0), QObject(), frequency(100), amplitude(60), isCarrier(false), isModulator(false) {}
@@ -16,18 +32,17 @@ Operator::Operator()
 Operator::Operator(const Operator &operator_)
         : id(operator_.id), frequency(operator_.frequency), amplitude(operator_.amplitude),
           isModulator(operator_.isModulator), isCarrier(operator_.isCarrier), modulatedBy(operator_.modulatedBy),
-          position(operator_.position), isBeingDragged(operator_.isBeingDragged),
-          draggingState(operator_.draggingState), initialDragCursorPos(operator_.initialDragCursorPos) {}
+          position(operator_.position), operatorViewState(operator_.operatorViewState) {}
 
 void Operator::setFrequency(long step) {
-    if(((this->frequency + step) <= 200) && ((this->frequency + step) > 0)){
-        this->frequency = this->frequency+step;
+    if (((this->frequency + step) <= 200) && ((this->frequency + step) > 0)) {
+        this->frequency = this->frequency + step;
     }
 }
 
 void Operator::setAmplitude(long step) {
-    if(((this->amplitude + step) <= 100) && ((this->amplitude + step) >= 0)){
-        this->amplitude = this->amplitude+step;
+    if (((this->amplitude + step) <= 100) && ((this->amplitude + step) >= 0)) {
+        this->amplitude = this->amplitude + step;
     }
 }
 
@@ -71,31 +86,3 @@ void from_json(const json &j, Operator &o) {
     o.position.setY(j["position"]["y"].get<float>());
 }
 
-void to_json(json &j, const std::unique_ptr<Operator> &o) {
-    j = json{
-            {"id",          o->id},
-            {"frequency",   o->frequency},
-            {"amplitude",   o->amplitude},
-            {"isModulator", o->isModulator},
-            {"isCarrier",   o->isCarrier},
-            {"modulatedBy", o->modulatedBy},
-            {"position",    {
-                                    {"x", o->position.x()},
-                                    {"y", o->position.y()}
-                            }}
-    };
-}
-
-void from_json(const json &j, std::unique_ptr<Operator> &o) {
-    if (o == nullptr) {
-        o = std::make_unique<Operator>();
-    }
-    j["id"].get_to(o->id);
-    j["frequency"].get_to(o->frequency);
-    j["amplitude"].get_to(o->amplitude);
-    j["isModulator"].get_to(o->isModulator);
-    j["isCarrier"].get_to(o->isCarrier);
-    j["modulatedBy"].get_to(o->modulatedBy);
-    o->position.setX(j["position"]["x"].get<float>());
-    o->position.setY(j["position"]["y"].get<float>());
-}

--- a/src/Controller/Operator.cpp
+++ b/src/Controller/Operator.cpp
@@ -5,6 +5,7 @@
 #include "Operator.h"
 #include "qcolor.h"
 #include <iostream>
+#include <utility>
 
 // Operator view state
 
@@ -13,7 +14,7 @@ OperatorViewState::OperatorViewState() {
 }
 
 OperatorViewState::OperatorViewState(const OperatorViewState &operatorViewState) : draggingState(
-                                                                                           operatorViewState.draggingState),
+        operatorViewState.draggingState),
                                                                                    initialDragCursorPos(
                                                                                            operatorViewState.initialDragCursorPos) {
 
@@ -56,6 +57,13 @@ long Operator::getFreq() {
 QColor Operator::getColorForOperator() const {
     return QColor((int) ((log10((double) this->frequency) / 4.38) * 255.0), 20,
                   (int) ((log10((double) this->amplitude) / 4.38) * 255.0));
+}
+
+Operator::Operator(int id, long frequency, long amplitude, bool isModulator, bool isCarrier,
+                   std::vector<int> modulatedBy, QPointF position, QObject *parent)
+        : id(id), frequency(frequency), amplitude(amplitude), isModulator(isModulator), isCarrier(isCarrier),
+          modulatedBy(std::move(modulatedBy)), position(position) {
+
 }
 
 void to_json(json &j, const Operator &o) {

--- a/src/Controller/Operator.cpp
+++ b/src/Controller/Operator.cpp
@@ -8,13 +8,11 @@
 
 // Operator view state
 
-OperatorViewState::OperatorViewState() : isBeingDragged(false) {
+OperatorViewState::OperatorViewState() {
 
 }
 
-OperatorViewState::OperatorViewState(const OperatorViewState &operatorViewState) : isBeingDragged(
-        operatorViewState.isBeingDragged),
-                                                                                   draggingState(
+OperatorViewState::OperatorViewState(const OperatorViewState &operatorViewState) : draggingState(
                                                                                            operatorViewState.draggingState),
                                                                                    initialDragCursorPos(
                                                                                            operatorViewState.initialDragCursorPos) {

--- a/src/Controller/Operator.h
+++ b/src/Controller/Operator.h
@@ -18,6 +18,22 @@ enum class DraggingState {
     Dragging
 };
 
+// All state that is specifically just for the operator view
+struct OperatorViewState {
+    OperatorViewState();
+    OperatorViewState(const OperatorViewState &operatorViewState);
+
+    bool isBeingDragged{};
+    std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> timeSinceClick = std::nullopt;
+    DraggingState draggingState = DraggingState::None;
+    std::optional<QPointF> initialDragCursorPos;
+    std::optional<PointTweenAnimation> moveOperatorAnimation;
+    double sizeMultiplier = 1.0;
+    std::optional<TweenAnimation> sizeMultiplierAnim;
+    double opacity = 1.0;
+    std::optional<TweenAnimation> opacityAnim;
+};
+
 struct Operator:public QObject {
     Q_OBJECT
 public:
@@ -32,8 +48,7 @@ public:
     bool isCarrier;
     std::vector<int> modulatedBy;
     QPointF position;
-    bool isBeingDragged;
-    std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> timeSinceClick = std::nullopt;
+    OperatorViewState operatorViewState;
     Q_PROPERTY(int idProp MEMBER id)
     Q_PROPERTY(long freqProp MEMBER frequency)
     Q_PROPERTY(long ampProp MEMBER amplitude)
@@ -41,9 +56,6 @@ public:
     Q_INVOKABLE long getAmp();
     Q_INVOKABLE void setFrequency(long step);
     Q_INVOKABLE void setAmplitude(long step);
-    DraggingState draggingState = DraggingState::None;
-    std::optional<QPointF> initialDragCursorPos;
-    std::optional<PointTweenAnimation> moveOperatorAnimation;
 
     // Schedule the operator to be deleted since deleting it is not possible while iterating over the operators
     bool scheduleForRemoval = false;
@@ -52,8 +64,5 @@ public:
 
 void to_json(json& j, const Operator& o);
 void from_json(const json& j, Operator& o);
-
-void to_json(json& j, const std::unique_ptr<Operator>& o);
-void from_json(const json& j, std::unique_ptr<Operator>& o);
 
 #endif //QTQUICKTEST_OPERATOR_H

--- a/src/Controller/Operator.h
+++ b/src/Controller/Operator.h
@@ -23,7 +23,7 @@ struct OperatorViewState {
     OperatorViewState();
     OperatorViewState(const OperatorViewState &operatorViewState);
 
-    std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> timeSinceClick = std::nullopt;
+    std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> initialClickTime = std::nullopt;
     DraggingState draggingState = DraggingState::None;
     std::optional<QPointF> initialDragCursorPos;
     std::optional<PointTweenAnimation> moveOperatorAnimation;

--- a/src/Controller/Operator.h
+++ b/src/Controller/Operator.h
@@ -40,6 +40,7 @@ struct Operator:public QObject {
 public:
     Operator();
     Operator(int id, QObject* parent=0);
+    Operator(int id, long frequency, long amplitude, bool isModulator, bool isCarrier, std::vector<int> modulatedBy, QPointF position, QObject* parent=0);
     Operator(const Operator& operator_);
 
     int id;

--- a/src/Controller/Operator.h
+++ b/src/Controller/Operator.h
@@ -23,7 +23,6 @@ struct OperatorViewState {
     OperatorViewState();
     OperatorViewState(const OperatorViewState &operatorViewState);
 
-    bool isBeingDragged{};
     std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> timeSinceClick = std::nullopt;
     DraggingState draggingState = DraggingState::None;
     std::optional<QPointF> initialDragCursorPos;
@@ -32,6 +31,8 @@ struct OperatorViewState {
     std::optional<TweenAnimation> sizeMultiplierAnim;
     double opacity = 1.0;
     std::optional<TweenAnimation> opacityAnim;
+    double connectIconOpacity = 0.3;
+    std::optional<TweenAnimation> connectIconOpacityAnim;
 };
 
 struct Operator:public QObject {

--- a/src/OperatorPresetsView/OperatorPresetView.cpp
+++ b/src/OperatorPresetsView/OperatorPresetView.cpp
@@ -17,7 +17,8 @@ const double kPresetBackgroundAnimTime = 100.0;
 
 OperatorPresetView::OperatorPresetView(OperatorPresetsView *operatorPresetView, QString name, Preset preset)
         : operatorPresetsView_(operatorPresetView), name_(std::move(name)), preset_(std::move(preset)),
-          presetBackgroundAnim_(kPresetBackgroundAnimTime, kPresetBackgroundColor, kPresetBackgroundHoverColor, AnimationCurves::easeOut) {
+          presetBackgroundColor_(kPresetBackgroundColor),
+          presetBackgroundAnim_(kPresetBackgroundAnimTime, &presetBackgroundColor_, kPresetBackgroundColor, kPresetBackgroundHoverColor, AnimationCurves::easeOut) {
     operatorsMinMax_ = findMinMaxOfOperators(preset_.operators);
 }
 
@@ -54,7 +55,7 @@ void OperatorPresetView::paintPreview(QPainter *painter, const QPointF &pos, con
                                  size - (size * kOperatorBoxPadding * 2.0) - QSizeF(kOperatorSize, kOperatorSize));
 
     painter->setPen(Qt::PenStyle::NoPen);
-    painter->setBrush(QColor(presetBackgroundAnim_.value()));
+    painter->setBrush(presetBackgroundColor_);
     painter->drawRoundedRect(QRectF(pos, size), 8, 8);
 
     // Draw the modulator lines

--- a/src/OperatorPresetsView/OperatorPresetView.h
+++ b/src/OperatorPresetsView/OperatorPresetView.h
@@ -26,6 +26,7 @@ private:
     // The range of coordinates that the operators are inside
     std::pair<QPointF, QPointF> operatorsMinMax_;
     ColorTweenAnimation presetBackgroundAnim_;
+    QColor presetBackgroundColor_;
 };
 
 

--- a/src/OperatorPresetsView/OperatorPresetsView.h
+++ b/src/OperatorPresetsView/OperatorPresetsView.h
@@ -33,10 +33,11 @@ private:
     void updateSizes();
     void addNewPreset();
 
-    std::optional<std::vector<OperatorPresetView>> operatorPresetViews_;
+    std::optional<std::vector<std::unique_ptr<OperatorPresetView>>> operatorPresetViews_;
     QSizeF presetBoxSize;
     ColorTweenAnimation addPresetBackgroundAnim_;
     TouchPoint lastTouchPoint_;
+    QColor addPresetBackgroundColor_;
 };
 
 

--- a/src/OperatorView/AddOperatorBox.cpp
+++ b/src/OperatorView/AddOperatorBox.cpp
@@ -55,6 +55,6 @@ bool AddOperatorBox::isInsideBox(const QPointF &coords) {
 
 bool AddOperatorBox::isAnyPointBeingDragged() {
     const auto& controller = Controller::instance;
-    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.isBeingDragged; });
+    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.operatorViewState.isBeingDragged; });
 }
 

--- a/src/OperatorView/AddOperatorBox.cpp
+++ b/src/OperatorView/AddOperatorBox.cpp
@@ -21,15 +21,15 @@ void AddOperatorBox::update() {
     boxPos_.setX(operatorView_->width() - kBoxSize - kRightAnchor);
     boxPos_.setY(kPositionY);
 
-    const auto pos = operatorView_->touchPoint().position;
+    const auto pos = operatorView_->primaryTouchPoint().position;
 
-    if (isInsideBox(pos) && operatorView_->touchPoint().isPressed && !operatorCreated_) {
+    if (isInsideBox(pos) && operatorView_->primaryTouchPoint().isPressed && !operatorCreated_) {
         const auto newOperatorPos = operatorView_->fromViewCoords(QPointF(pos.x() - kBoxSize / 2.0, pos.y() - kBoxSize / 2.0));
         operatorView_->addOperator(newOperatorPos.x(), newOperatorPos.y());
         operatorCreated_ = true;
         operatorView_->touchPressHandledState_ = TouchEventHandledState::Handled;
     }
-    else if (!isInsideBox(pos) && !operatorView_->touchPoint().isPressed) {
+    else if (!isInsideBox(pos) && !operatorView_->primaryTouchPoint().isPressed) {
         operatorCreated_ = false;
     }
 }
@@ -55,6 +55,6 @@ bool AddOperatorBox::isInsideBox(const QPointF &coords) {
 
 bool AddOperatorBox::isAnyPointBeingDragged() {
     const auto& controller = Controller::instance;
-    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.operatorViewState.isBeingDragged; });
+    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.operatorViewState.draggingState == DraggingState::Dragging; });
 }
 

--- a/src/OperatorView/AddOperatorBox.cpp
+++ b/src/OperatorView/AddOperatorBox.cpp
@@ -23,7 +23,7 @@ void AddOperatorBox::update() {
 
     const auto pos = operatorView_->primaryTouchPoint().position;
 
-    if (isInsideBox(pos) && operatorView_->primaryTouchPoint().isPressed && !operatorCreated_) {
+    if (isInsideBox(pos) && operatorView_->primaryTouchPoint().isPressed && !operatorCreated_ && !isAnyOperatorBeingDragged()) {
         const auto newOperatorPos = operatorView_->fromViewCoords(QPointF(pos.x() - kBoxSize / 2.0, pos.y() - kBoxSize / 2.0));
         operatorView_->addOperator(newOperatorPos.x(), newOperatorPos.y());
         operatorCreated_ = true;
@@ -53,8 +53,8 @@ bool AddOperatorBox::isInsideBox(const QPointF &coords) {
     return coords.x() >= boxPos_.x() && coords.x() < boxPos_.x() + kBoxSize && coords.y() >= boxPos_.y() && coords.y() < boxPos_.y() + kBoxSize;
 }
 
-bool AddOperatorBox::isAnyPointBeingDragged() {
+bool AddOperatorBox::isAnyOperatorBeingDragged() {
     const auto& controller = Controller::instance;
-    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.operatorViewState.draggingState == DraggingState::Dragging; });
+    return q20::ranges::any_of(controller->operators().begin(), controller->operators().end(), [] (const auto& kv) { return kv.second.operatorViewState.draggingState != DraggingState::None; });
 }
 

--- a/src/OperatorView/AddOperatorBox.h
+++ b/src/OperatorView/AddOperatorBox.h
@@ -17,7 +17,7 @@ public:
     void draw(QPainter* qPainter);
 private:
     bool isInsideBox(const QPointF& coords);
-    bool isAnyPointBeingDragged();
+    bool isAnyOperatorBeingDragged();
 
     QPointF boxPos_;
     OperatorView *operatorView_;

--- a/src/OperatorView/OperatorDrawer.cpp
+++ b/src/OperatorView/OperatorDrawer.cpp
@@ -163,8 +163,9 @@ void OperatorDrawer::onOperatorPressed(Operator &operator_) {
 void OperatorDrawer::updateOperatorDrag(Operator &operator_) {
     const auto &controller = Controller::instance;
     const auto touchPointPos = operatorView_->primaryTouchPoint().position;
+    const auto scaledBoxSize = kBoxSize * operator_.operatorViewState.sizeMultiplier;
     const auto operatorPos = operatorView_->fromViewCoords(
-            QPointF(touchPointPos.x() - kBoxSize / 2.0, touchPointPos.y() - kBoxSize / 2.0));
+            QPointF(touchPointPos.x() - scaledBoxSize / 2.0, touchPointPos.y() - scaledBoxSize / 2.0));
     operator_.position.setX(operatorPos.x());
     operator_.position.setY(operatorPos.y());
 

--- a/src/OperatorView/OperatorDrawer.cpp
+++ b/src/OperatorView/OperatorDrawer.cpp
@@ -403,3 +403,7 @@ void OperatorDrawer::fixOperatorPositionAfterDrop(Operator &operator_, float mov
         }
     }
 }
+
+const std::optional<int> &OperatorDrawer::draggedOperatorId() {
+    return draggedOperatorId_;
+}

--- a/src/OperatorView/OperatorDrawer.cpp
+++ b/src/OperatorView/OperatorDrawer.cpp
@@ -306,12 +306,11 @@ OperatorDrawer::drawCurvedModulatorLine(QPainter *painter, const Operator &modul
     const auto endPoint = pointToVector(modulatedPos) + perpToLine * kCurvedLineMargin;
 
     std::vector<QPointF> linePoints;
-    for (int i = 0; i < kModulatorCurvedLinePointCount-1; i++) {
+    for (int i = 0; i < kModulatorCurvedLinePointCount; i++) {
+        // Divide by number of points - 1, since that is the index of the last point
         const double fraction = static_cast<double>(i) / static_cast<double>(kModulatorCurvedLinePointCount-1);
         linePoints.push_back(vectorToPoint(bezierCurve(startPoint, curveControlPoint, endPoint, fraction)));
     }
-    // The curve sometimes doesn't go through the end point, so we just add the end point to make sure it always does
-    linePoints.push_back(vectorToPoint(endPoint));
 
     painter->setPen(QPen(modulatorOp.getColorForOperator(), kModulatorLineWidth));
     painter->setBrush(modulatorOp.getColorForOperator());

--- a/src/OperatorView/OperatorDrawer.cpp
+++ b/src/OperatorView/OperatorDrawer.cpp
@@ -266,10 +266,10 @@ void OperatorDrawer::draw(QPainter *painter, const Operator &operator_) {
         const auto modulatedPos = closestPointInBox(modulatorOpPos, modulatedOpPos, modulatedBoxSize, modulatedBoxSize);
 
         if (std::count(modulatorOp.modulatedBy.begin(), modulatorOp.modulatedBy.end(), operator_.id) != 0) {
-            drawCurvedModulatorLine(painter, operator_, modulatorPos, modulatedPos);
+            drawCurvedModulatorLine(painter, modulatorOp, modulatorPos, modulatedPos);
         }
         else {
-            drawModulatorLine(painter, operator_, modulatorPos, modulatedPos);
+            drawModulatorLine(painter, modulatorOp, modulatorPos, modulatedPos);
         }
     }
 }

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -23,7 +23,8 @@ private:
 
 
     OperatorView *operatorView_;
-    bool isPointBeingDragged_ = false;
+    bool isAnyOperatorBeingDragged_ = false;
+    int draggedOperatorId_ = -1;
 };
 
 

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -39,6 +39,9 @@ private:
 
     void drawOperatorConnectIcon(QPainter *painter, const QRectF &operatorBoxRect, const Operator &operator_,
                                  const int selectedOperatorId);
+
+    void drawCurvedModulatorLine(QPainter *painter, const Operator &modulatorOp, const QPointF &modulatorPos,
+                                 const QPointF &modulatedPos);
 };
 
 

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -33,6 +33,9 @@ private:
     OperatorView *operatorView_;
     DraggingState currentDraggingOperatorState_ = DraggingState::None;
     std::optional<int> draggedOperatorId_ = std::nullopt;
+
+    void drawOperatorConnectIcon(QPainter *painter, const QRectF &operatorBoxRect, const Operator &operator_,
+                                 const int selectedOperatorId);
 };
 
 

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -17,9 +17,15 @@ public:
     void update(Operator& operator_);
     void draw(QPainter *painter, const Operator& operator_);
 private:
-    void updateAnimations(Operator &operator_);
+    void toggleModulator(Operator &operator_, int modulatorId);
+    void onTouchDown(Operator &operator_);
     void startDragging(Operator &operator_);
+    void onOperatorPressed(Operator &operator_);
+    void updateOperatorDrag(Operator &operator_);
+    void releaseOperator(Operator &operator_);
+    void updateAnimations(Operator &operator_);
     void drawBox(QPainter *painter, const Operator &operator_);
+    void drawModulatorLine(QPainter *painter, const Operator& modulatorOp, const QPointF &modulatorPos, const QPointF &modulatedPos);
     bool isInsideBox(const Operator& operator_, const QPointF& coords);
     void fixOperatorPositionAfterDrop(Operator& operator_, float moveMultiplier = 1.1f);
 
@@ -27,16 +33,6 @@ private:
     OperatorView *operatorView_;
     DraggingState currentDraggingOperatorState_ = DraggingState::None;
     std::optional<int> draggedOperatorId_ = std::nullopt;
-
-    void toggleModulator(Operator &operator_, int modulatorId);
-
-    void onTouchDown(Operator &operator_);
-
-    void onOperatorPressed(Operator &operator_);
-
-    void updateOperatorDrag(Operator &operator_);
-
-    void releaseOperator(Operator &operator_);
 };
 
 

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -17,14 +17,26 @@ public:
     void update(Operator& operator_);
     void draw(QPainter *painter, const Operator& operator_);
 private:
+    void updateAnimations(Operator &operator_);
+    void startDragging(Operator &operator_);
     void drawBox(QPainter *painter, const Operator &operator_);
     bool isInsideBox(const Operator& operator_, const QPointF& coords);
     void fixOperatorPositionAfterDrop(Operator& operator_, float moveMultiplier = 1.1f);
 
 
     OperatorView *operatorView_;
-    bool isAnyOperatorBeingDragged_ = false;
-    int draggedOperatorId_ = -1;
+    DraggingState currentDraggingOperatorState_ = DraggingState::None;
+    std::optional<int> draggedOperatorId_ = std::nullopt;
+
+    void toggleModulator(Operator &operator_, int modulatorId);
+
+    void onTouchDown(Operator &operator_);
+
+    void onOperatorPressed(Operator &operator_);
+
+    void updateOperatorDrag(Operator &operator_);
+
+    void releaseOperator(Operator &operator_);
 };
 
 

--- a/src/OperatorView/OperatorDrawer.h
+++ b/src/OperatorView/OperatorDrawer.h
@@ -16,6 +16,9 @@ public:
     OperatorDrawer(OperatorView *operatorView);
     void update(Operator& operator_);
     void draw(QPainter *painter, const Operator& operator_);
+
+    const std::optional<int>& draggedOperatorId();
+
 private:
     void toggleModulator(Operator &operator_, int modulatorId);
     void onTouchDown(Operator &operator_);

--- a/src/OperatorView/OperatorView.cpp
+++ b/src/OperatorView/OperatorView.cpp
@@ -33,7 +33,16 @@ void OperatorView::paint(QPainter *painter) {
     deleteOperatorBox_->draw(painter);
     drawCarrierLine(painter);
     for (const auto& operator_: controller->operators()) {
+        if (operator_.second.operatorViewState.draggingState != DraggingState::None) {
+            continue;
+        }
+
         operatorDrawer_->draw(painter, operator_.second);
+    }
+    // Draw the operator that is being dragged last so that it is on top of the other operators
+    if (operatorDrawer_->draggedOperatorId().has_value()) {
+        const auto& selectedOperator = controller->getOperatorById(operatorDrawer_->draggedOperatorId().value());
+        operatorDrawer_->draw(painter, selectedOperator);
     }
 
     // Make a copy of all operator ids that should be deleted, then delete them in another loop.

--- a/src/OperatorView/OperatorView.cpp
+++ b/src/OperatorView/OperatorView.cpp
@@ -23,11 +23,11 @@ OperatorView::OperatorView(QQuickItem *parent) : QQuickPaintedItem(parent),
 void OperatorView::paint(QPainter *painter) {
     auto& controller = Controller::instance;
 
-    newBox_->update();
     deleteOperatorBox_->update();
     for (auto& operator_: controller->operators()) {
         operatorDrawer_->update(operator_.second);
     }
+    newBox_->update();
 
     newBox_->draw(painter);
     deleteOperatorBox_->draw(painter);

--- a/src/OperatorView/OperatorView.h
+++ b/src/OperatorView/OperatorView.h
@@ -37,7 +37,9 @@ public:
     const std::unique_ptr<DeleteOperatorBox>& deleteOperatorBox();
     QPointF toViewCoords(const QPointF& pos);
     QPointF fromViewCoords(const QPointF& pos);
-    const TouchPoint &touchPoint();
+    const TouchPoint &primaryTouchPoint();
+    TouchPoint &secondaryTouchPoint();
+    bool isUsingMouse();
 
     TouchEventHandledState touchPressHandledState_ = TouchEventHandledState::None;
 protected:
@@ -50,7 +52,9 @@ private:
     std::unique_ptr<OperatorDrawer> operatorDrawer_;
     std::unique_ptr<AddOperatorBox> newBox_;
     std::unique_ptr<DeleteOperatorBox> deleteOperatorBox_;
-    TouchPoint lastTouchPoint_;
+    TouchPoint primaryTouchPoint_;
+    TouchPoint secondaryTouchPoint_;
+    bool isUsingMouse_;
 
     void drawCarrierLine(QPainter *painter);
 };

--- a/src/Utils/ColorTweenAnimation.cpp
+++ b/src/Utils/ColorTweenAnimation.cpp
@@ -5,22 +5,27 @@
 #include "ColorTweenAnimation.h"
 #include "Utils.h"
 
-ColorTweenAnimation::ColorTweenAnimation(double ms, QColor from, QColor to,
-                                         std::function<double(double x)> animationCurve) : tweenAnimation_(ms,
+ColorTweenAnimation::ColorTweenAnimation(double ms, QColor* color, QColor from, QColor to,
+                                         std::function<double(double x)> animationCurve) : tweenAnimation_(ms, &fraction_,
                                                                                                            animationCurve),
                                                                                            fromColor_(from),
                                                                                            toColor_(to),
-                                                                                           color_(from) {
+                                                                                           color_(color) {
 
+}
+
+ColorTweenAnimation::ColorTweenAnimation(const ColorTweenAnimation &colorTweenAnimation) :fraction_(colorTweenAnimation.fraction_),
+                                                                                    tweenAnimation_(colorTweenAnimation.tweenAnimation_),
+                                                                                    fromColor_(colorTweenAnimation.fromColor_),
+                                                                                    toColor_(colorTweenAnimation.fromColor_),
+                                                                                    color_(colorTweenAnimation.color_) {
+    // Memory location of fraction_ changes when ColorTweenAnimation is copied, so we need to update it in tweenAnimation_
+    tweenAnimation_.setValuePtr(&fraction_);
 }
 
 void ColorTweenAnimation::update() {
     tweenAnimation_.update();
-    color_ = colorLerp(fromColor_, toColor_, tweenAnimation_.value());
-}
-
-const QColor &ColorTweenAnimation::value() {
-    return color_;
+    *color_ = colorLerp(fromColor_, toColor_, fraction_);
 }
 
 void ColorTweenAnimation::setForward() {

--- a/src/Utils/ColorTweenAnimation.h
+++ b/src/Utils/ColorTweenAnimation.h
@@ -11,19 +11,22 @@
 
 class ColorTweenAnimation {
 public:
-    ColorTweenAnimation(double ms, QColor from, QColor to, std::function<double(double x)> animationCurve = AnimationCurves::linear);
+    ColorTweenAnimation(double ms, QColor *color, QColor from, QColor to,
+                        std::function<double(double x)> animationCurve = AnimationCurves::linear);
+    ColorTweenAnimation(const ColorTweenAnimation &colorTweenAnimation);
+
     void setForward();
     void setReverse();
     void stop();
     void update();
-    const QColor& value();
     bool isRunning();
     bool isAtStart();
     bool isAtEnd();
 
 private:
     TweenAnimation tweenAnimation_;
-    QColor color_;
+    double fraction_;
+    QColor *color_;
     QColor fromColor_;
     QColor toColor_;
 };

--- a/src/Utils/PointTweenAnimation.h
+++ b/src/Utils/PointTweenAnimation.h
@@ -11,22 +11,25 @@
 
 class PointTweenAnimation {
 public:
-    PointTweenAnimation(double ms, QPointF from, QPointF to,
+    PointTweenAnimation(double ms, QPointF *point, QPointF from, QPointF to,
                         std::function<double(double x)> animationCurve = AnimationCurves::linear);
+    PointTweenAnimation(const PointTweenAnimation& pointTweenAnimation);
+
     void setForward();
     void setReverse();
     void stop();
     void update();
-    const QPointF &value() const;
     bool isRunning();
     bool isAtStart();
     bool isAtEnd();
+    PointTweenAnimation& operator=(const PointTweenAnimation& other);
 
     QPointF fromPoint_;
     QPointF toPoint_;
 private:
     TweenAnimation tweenAnimation_;
-    QPointF point_;
+    double fraction_;
+    QPointF *point_;
 };
 
 

--- a/src/Utils/TouchPoint.h
+++ b/src/Utils/TouchPoint.h
@@ -8,8 +8,10 @@
 #include <QPointF>
 
 struct TouchPoint {
-    bool isPressed;
+    int id = -1;
+    bool isPressed = false;
     QPointF position;
+    bool initialPressHandled = false;
 };
 
 #endif //MAIN_QML_TOUCHPOINT_H

--- a/src/Utils/TweenAnimation.cpp
+++ b/src/Utils/TweenAnimation.cpp
@@ -6,7 +6,9 @@
 
 #include <utility>
 
-TweenAnimation::TweenAnimation(double ms, double* value, std::function<double (double x)> animationCurve, double from, double to) : animTimeMs_(ms), animationCurve_(std::move(animationCurve)), value_(value), fromValue_(from), toValue_(to) {
+TweenAnimation::TweenAnimation(double ms, double *value, std::function<double(double x)> animationCurve, double from,
+                               double to, bool loop) : animTimeMs_(ms), animationCurve_(std::move(animationCurve)), value_(value),
+                                            fromValue_(from), toValue_(to), loop_(loop) {
 
 }
 
@@ -20,8 +22,7 @@ void TweenAnimation::setForward() {
         const auto timeElapsed = std::chrono::duration<double, std::milli>(currentTime - startTime_.value()).count();
         const auto timeRemaining = (int) (animTimeMs_ - timeElapsed);
         startTime_ = std::chrono::high_resolution_clock::now() - std::chrono::duration<int, std::milli>(timeRemaining);
-    }
-    else {
+    } else {
         startTime_ = std::chrono::high_resolution_clock::now();
     }
 
@@ -38,8 +39,7 @@ void TweenAnimation::setReverse() {
         const auto timeElapsed = std::chrono::duration<double, std::milli>(currentTime - startTime_.value()).count();
         const auto timeRemaining = (int) (animTimeMs_ - timeElapsed);
         startTime_ = std::chrono::high_resolution_clock::now() - std::chrono::duration<int, std::milli>(timeRemaining);
-    }
-    else {
+    } else {
         startTime_ = std::chrono::high_resolution_clock::now();
     }
 
@@ -59,8 +59,19 @@ void TweenAnimation::update() {
     const auto timeElapsed = std::chrono::duration<double, std::milli>(currentTime - startTime_.value()).count();
 
     if (timeElapsed >= animTimeMs_) {
+        const auto previousAnimationState = animationState_;
+
         *value_ = animationState_ == TweenAnimationState::Forward ? toValue_ : fromValue_;
         animationState_ = TweenAnimationState::Stop;
+
+        if (loop_) {
+            if (previousAnimationState == TweenAnimationState::Forward) {
+                setReverse();
+            }
+            else {
+                setForward();
+            }
+        }
         return;
     }
 

--- a/src/Utils/TweenAnimation.cpp
+++ b/src/Utils/TweenAnimation.cpp
@@ -14,6 +14,7 @@ TweenAnimation::TweenAnimation(double ms, double *value, std::function<double(do
 
 void TweenAnimation::setForward() {
     if (animationState_ == TweenAnimationState::Forward || isAtEnd()) {
+        animationState_ = TweenAnimationState::Stop;
         return;
     }
 
@@ -31,6 +32,7 @@ void TweenAnimation::setForward() {
 
 void TweenAnimation::setReverse() {
     if (animationState_ == TweenAnimationState::Reverse || isAtStart()) {
+        animationState_ = TweenAnimationState::Stop;
         return;
     }
 

--- a/src/Utils/TweenAnimation.cpp
+++ b/src/Utils/TweenAnimation.cpp
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-TweenAnimation::TweenAnimation(double ms, std::function<double (double x)> animationCurve, double from, double to) : animTimeMs_(ms), animationCurve_(std::move(animationCurve)), fromValue_(from), toValue_(to) {
+TweenAnimation::TweenAnimation(double ms, double* value, std::function<double (double x)> animationCurve, double from, double to) : animTimeMs_(ms), animationCurve_(std::move(animationCurve)), value_(value), fromValue_(from), toValue_(to) {
 
 }
 
@@ -59,20 +59,16 @@ void TweenAnimation::update() {
     const auto timeElapsed = std::chrono::duration<double, std::milli>(currentTime - startTime_.value()).count();
 
     if (timeElapsed >= animTimeMs_) {
-        value_ = animationState_ == TweenAnimationState::Forward ? toValue_ : fromValue_;
+        *value_ = animationState_ == TweenAnimationState::Forward ? toValue_ : fromValue_;
         animationState_ = TweenAnimationState::Stop;
         return;
     }
 
-    value_ = animationCurve_(timeElapsed / animTimeMs_) * (toValue_ - fromValue_) + fromValue_;
+    *value_ = animationCurve_(timeElapsed / animTimeMs_) * (toValue_ - fromValue_) + fromValue_;
 
     if (animationState_ == TweenAnimationState::Reverse) {
-        value_ = toValue_ - (value_ - fromValue_);
+        *value_ = toValue_ - (*value_ - fromValue_);
     }
-}
-
-double TweenAnimation::value() {
-    return value_;
 }
 
 bool TweenAnimation::isRunning() {
@@ -80,10 +76,13 @@ bool TweenAnimation::isRunning() {
 }
 
 bool TweenAnimation::isAtStart() {
-    return value_ == fromValue_;
+    return *value_ == fromValue_;
 }
 
 bool TweenAnimation::isAtEnd() {
-    return value_ == toValue_;
+    return *value_ == toValue_;
 }
 
+void TweenAnimation::setValuePtr(double *value) {
+    value_ = value;
+}

--- a/src/Utils/TweenAnimation.h
+++ b/src/Utils/TweenAnimation.h
@@ -31,6 +31,10 @@ namespace AnimationCurves {
         return 1.0 - std::pow(1.0 - x, 2.0);
     }
 
+    inline double easeInOut(double x) {
+        return x < 0.5 ? 2 * std::pow(x, 2.0) : 1 - std::pow(-2 * x + 2, 2) / 2;
+    }
+
     inline double easeOutBack(double x) {
         const auto c1 = 1.70158;
         const auto c3 = c1 + 1.0;
@@ -42,7 +46,7 @@ namespace AnimationCurves {
 class TweenAnimation {
 public:
     TweenAnimation(double ms, double* value, std::function<double(double x)> animationCurve = AnimationCurves::linear,
-                   double from = 0.0, double to = 1.0);
+                   double from = 0.0, double to = 1.0, bool loop = false);
 
     void setForward();
     void setReverse();
@@ -61,6 +65,7 @@ private:
     double fromValue_;
     double toValue_;
     double* value_;
+    bool loop_;
 };
 
 

--- a/src/Utils/TweenAnimation.h
+++ b/src/Utils/TweenAnimation.h
@@ -41,17 +41,17 @@ namespace AnimationCurves {
 
 class TweenAnimation {
 public:
-    explicit TweenAnimation(double ms, std::function<double(double x)> animationCurve = AnimationCurves::linear,
-                            double from = 0.0, double to = 1.0);
+    TweenAnimation(double ms, double* value, std::function<double(double x)> animationCurve = AnimationCurves::linear,
+                   double from = 0.0, double to = 1.0);
 
     void setForward();
     void setReverse();
     void stop();
     void update();
-    double value();
     bool isRunning();
     bool isAtStart();
     bool isAtEnd();
+    void setValuePtr(double *value);
 
 private:
     std::function<double(double x)> animationCurve_;
@@ -60,7 +60,7 @@ private:
     double animTimeMs_;
     double fromValue_;
     double toValue_;
-    double value_;
+    double* value_;
 };
 
 

--- a/src/Utils/Utils.h
+++ b/src/Utils/Utils.h
@@ -50,6 +50,10 @@ inline QVector2D pointToVector(const QPointF& point) {
     return {(float) point.x(), (float) point.y()};
 }
 
+inline QPointF vectorToPoint(const QVector2D& vector) {
+    return {vector.x(), vector.y()};
+}
+
 inline QVector2D vectorBetweenPoints(const QPointF& from, const QPointF& to) {
     return pointToVector(to) - pointToVector(from);
 }

--- a/src/Utils/Utils.h
+++ b/src/Utils/Utils.h
@@ -67,6 +67,10 @@ inline QPointF operator +(const QPointF& point, const QVector2D& vector) {
     return { point.x() + vector.x(), point.y() + vector.y() };
 }
 
+inline QVector2D bezierCurve(const QVector2D& p0, const QVector2D& p1, const QVector2D p2, const double t) {
+    return std::pow(1.0 - t, 2) * p0 + 2.0 * (1.0 - t) * t * p1 + std::pow(t, 2) * p2;
+}
+
 inline QColor colorLerp(const QColor& from, const QColor& to, const double fraction) {
     const auto red = (int) ((to.red() - from.red()) * fraction + from.red());
     const auto green = (int) ((to.green() - from.green()) * fraction + from.green());


### PR DESCRIPTION
* Show arrow at the end of modulator line
* Show curved lines when two operators are modulating each other
* Connect operators while operator is being dragged, instead of when selected (only when using touch screen)
* Show icon on other operators when you can connect a modulator to them by tapping on them
* Make operator larger when dragging