### PR TITLE
Fixed state of presets button when clicked outside of the preset box

### DIFF
--- a/src/Controller/Controller.cpp
+++ b/src/Controller/Controller.cpp
@@ -275,7 +275,7 @@ void Controller::changeToPreset(const Preset &preset) {
 
     //Alert that a preset has been loaded
     QString str = QString("the preset '%1' has been loaded!").arg(preset.name);
-    AlertController::instance->showAlert(str, 0);
+//    AlertController::instance->showAlert(str, 0);
 
 }
 
@@ -313,10 +313,14 @@ void Controller::resetAvailableOperatorIds() {
 }
 
 void Controller::hidePresets() {
-    showPresets_ = false;
-    showPresetsChanged(false);
+    if(showPresets_ == true){
+        showPresets_ = false;
+        emit showPresetsChanged(false);
+    }
 }
 
+//void Controller::showPresets_() {
+//}?
 double Controller::getOperatorModulationValue(int operatorId, int offset) {
     auto& operator_ = getOperatorById(operatorId);
     operator_.visitedCount++;

--- a/src/OperatorPresetsView/OperatorPresetsView.cpp
+++ b/src/OperatorPresetsView/OperatorPresetsView.cpp
@@ -86,7 +86,7 @@ void OperatorPresetsView::paintAddPresetButton(QPainter *painter, const QPointF 
 
 void OperatorPresetsView::loadPresets() {
     if (!std::filesystem::directory_entry("presets/").exists()) {
-        qDebug() << "Presets directory does not exist";
+//        qDebug() << "Presets directory does not exist";
         return;
     }
 

--- a/src/OperatorView/PresetButton.cpp
+++ b/src/OperatorView/PresetButton.cpp
@@ -1,7 +1,7 @@
 //
 // Created by Sigurður on 4/25/2023.
 //
-
+#include <iostream>
 #include "PresetButton.h"
 #include "QPainter"
 
@@ -81,7 +81,6 @@ void PresetButton::mouseReleaseEvent(QMouseEvent *event)
 
 bool PresetButton::updateOpen() {
     open_ = !open_;
-
     if (open_) { //if the button displays all available presets then display a certain icon
         icon_ = iconOn_;
         color_ = colorOpen_;
@@ -89,6 +88,7 @@ bool PresetButton::updateOpen() {
         icon_ = iconOff_;
         color_ = colorClosed_;
     }
+    update();
 
     return open_;
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -67,6 +67,12 @@ Window {
             opWaveView.setColor(color);
             opDrag.color = color.alpha(0.5).darker(3);
         }
+        function onShowPresetsChanged(show){
+//            if(!show ){
+                var a =  presetB.updateOpen; // Since this is updated in OperatorView.cpp we need to catch the signal.
+//            }
+        }
+
     }
 
     Material.theme: Material.Dark
@@ -173,7 +179,7 @@ Window {
             anchors.topMargin: 50;
 
             onClicked: {
-                presetB.updateOpen
+//                presetB.updateOpen;
                 controller.deselectOperator()
                 controller.showPresets = !controller.showPresets;
             }
@@ -242,7 +248,7 @@ Window {
                 width: 12
                 height: 10
                 text: "0"
-                anchors.left: parent.left
+//                anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.horizontalCenter: opDrag.horizontalCenter
                 anchors.rightMargin: 319


### PR DESCRIPTION
Helsta breytingin var í controller::hidePresets() þar sem ég setti in tjekk til að sjá hvort presets gluggin væri nú þegar opin eða ekki og emitt-a showPresetsChanged. 
Í main.qml setti ég fall í connections sem update-ar presets takkan þegar hann fær notification að state-ið á takkanum var breytt, þ.e. frá showPresetsChanged.


